### PR TITLE
Z3.dev: Install using the make install target

### DIFF
--- a/packages/Z3/Z3.dev/opam
+++ b/packages/Z3/Z3.dev/opam
@@ -10,7 +10,7 @@ build: [
   [make "-C" "build" "-j" jobs]
 ]
 install: [
-  [make "-C" "build" "ocamlfind_install"]
+  [make "-C" "build" "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "Z3"]


### PR DESCRIPTION
The `ocamlfind_install` target doesn't exist anymore.
